### PR TITLE
🐛 fix: add empty state and improve search crash handling

### DIFF
--- a/docs/components/Dashboard.tsx
+++ b/docs/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import emojilib from '@lobehub/emojilib';
 import { FluentEmoji, FluentEmojiProps, getFluentEmojiCDN } from '@lobehub/fluent-emoji';
-import { Flexbox, SearchBar, TooltipGroup } from '@lobehub/ui';
+import { Empty, Flexbox, SearchBar, TooltipGroup } from '@lobehub/ui';
 import { Segmented } from 'antd';
 import { cssVar } from 'antd-style';
 import { memo, useMemo, useState } from 'react';
@@ -24,6 +24,9 @@ const Dashboard = memo(() => {
       <Flexbox align={'center'} gap={12} horizontal>
         <SearchBar
           defaultValue={keyword}
+          onChange={(e) => {
+            if (!e.target.value) setKeyword(undefined);
+          }}
           onSearch={(v) => setKeyword(v)}
           placeholder={'Search by emoji keywords...'}
           style={{ width: '100%' }}
@@ -59,25 +62,37 @@ const Dashboard = memo(() => {
           }}
         />
       </Flexbox>
-      <TooltipGroup>
-        <VirtuosoGridList
-          data={list}
-          initialItemCount={24}
-          itemContent={(_, [emoji, name]) => (
-            <EmojiItem
-              emoji={emoji}
-              key={name}
-              title={name}
-              url={getFluentEmojiCDN(emoji, { type: type as any })}
-            >
-              <FluentEmoji emoji={emoji} key={name} size={56} type={type} />
-            </EmojiItem>
-          )}
-          style={{
-            minHeight: '1050px',
-          }}
+      {list.length === 0 ? (
+        <Empty
+          description={`No emoji found for "${keyword}"`}
+          justify={'center'}
+          style={{ minHeight: '350px' }}
         />
-      </TooltipGroup>
+      ) : (
+        <TooltipGroup>
+          <VirtuosoGridList
+            data={list}
+            initialItemCount={24}
+            itemContent={(_, item) => {
+              if (!item) return null;
+              const [emoji, name] = item;
+              return (
+                <EmojiItem
+                  emoji={emoji}
+                  key={name}
+                  title={name}
+                  url={getFluentEmojiCDN(emoji, { type: type as any })}
+                >
+                  <FluentEmoji emoji={emoji} key={name} size={56} type={type} />
+                </EmojiItem>
+              );
+            }}
+            style={{
+              minHeight: '1050px',
+            }}
+          />
+        </TooltipGroup>
+      )}
     </Flexbox>
   );
 });

--- a/docs/components/VirtuosoGridList/index.tsx
+++ b/docs/components/VirtuosoGridList/index.tsx
@@ -9,10 +9,9 @@ const GridList = forwardRef<HTMLDivElement, GridProps>((props, ref) => (
 const VirtuosoGridList = memo<VirtuosoGridProps<any, any>>(
   ({ data, initialItemCount, ...rest }) => {
     const count = data && data?.length >= 8 ? 8 : data?.length;
-    const maxInitialItemCount =
-      data && data?.length && initialItemCount && initialItemCount > data?.length
-        ? data?.length
-        : initialItemCount;
+    const maxInitialItemCount = data
+      ? Math.min(initialItemCount ?? Infinity, data.length)
+      : initialItemCount;
     return (
       <VirtuosoGrid
         components={{ List: GridList }}


### PR DESCRIPTION
Fixes crash when a search returns zero results, and adds a proper empty state instead of a broken/blank UI.

- Add Empty component display when no emojis match search results
- Clear keyword when SearchBar input is emptied via onChange handler
- Add null safety check in VirtuosoGridList itemContent callback
- Simplify maxInitialItemCount calculation using Math.min

Fixes #8

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Fixes a crash when searching for a keyword with zero matching emoji, and adds a proper empty state instead of a broken UI.

**Root cause:**
1. `VirtuosoGridList/index.tsx`: `maxInitialItemCount` calculation used a truthy check on `data.length`, which treats `0` (empty results) the same as missing/undefined — so it kept `initialItemCount` (24) instead of correctly becoming `0`. This told the virtualized grid to render 24 items against an empty `data` array.
2. `Dashboard.tsx`: `itemContent` destructured `[emoji, name]` directly from the item without checking it existed, so the phantom `undefined` items threw a TypeError.

**Changes:**
- Add Empty component display when no emojis match search results
- Clear keyword when SearchBar input is emptied via onChange handler
- Add null safety check in VirtuosoGridList itemContent callback
- Simplify maxInitialItemCount calculation using Math.min

**Testing:**
- Searched a nonexistent keyword → empty state shown, no crash
- Searched a valid keyword afterward, without reloading → works normally

Fixes #8

#### 📝 补充信息 | Additional Information

Reproduced and confirmed both on production (fluent-emoji.lobehub.com) and locally via `bun dev`.
