### PR TITLE
🔨 build: replace father with tsdown to emit Node-ESM-resolvable output

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -1,5 +1,0 @@
-import { defineConfig } from 'father';
-
-export default defineConfig({
-  esm: { output: 'es', ignores: ['./src/components/**/*', './src/Editor/**/*'] },
-});

--- a/package.json
+++ b/package.json
@@ -17,14 +17,21 @@
   "license": "MIT",
   "author": "LobeHub <i@lobehub.com>",
   "sideEffects": false,
-  "main": "es/index.js",
-  "module": "es/index.js",
-  "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./es/index.d.mts",
+      "import": "./es/index.mjs",
+      "default": "./es/index.mjs"
+    }
+  },
+  "main": "es/index.mjs",
+  "module": "es/index.mjs",
+  "types": "es/index.d.mts",
   "files": [
     "es"
   ],
   "scripts": {
-    "build": "father build",
+    "build": "tsdown",
     "build:static": "tsx ./scripts/groupAnim.ts",
     "ci": "npm run lint && npm run type-check",
     "clean": "rm -r es lib dist coverage .dumi/tmp .eslintcache node_modules/.cache",
@@ -32,7 +39,6 @@
     "docs:build": "dumi build",
     "docs:build-analyze": "ANALYZE=1 dumi build",
     "docs:dev": "dumi dev",
-    "doctor": "father doctor",
     "lint": "eslint \"{src,packages}/**/*.{js,jsx,ts,tsx}\" --fix",
     "lint:circular": "dpdm src/**/*.{ts,tsx}  --warning false  --tree false  --exit-code circular:1  -T true",
     "lint:md": "remark . --quiet --frail --output",
@@ -96,7 +102,6 @@
     "dumi": "^2.4.21",
     "dumi-theme-lobehub": "^4.0.1",
     "eslint": "^8.57.1",
-    "father": "^4.6.11",
     "glob": "^13.0.0",
     "husky": "^9.1.7",
     "jsdom": "^27.3.0",
@@ -111,6 +116,7 @@
     "semantic-release": "^21.1.2",
     "sharp": "^0.34.5",
     "stylelint": "^15.11.0",
+    "tsdown": "^0.22.14",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "~1.2.2"

--- a/src/getEmojiByCharacter/index.ts
+++ b/src/getEmojiByCharacter/index.ts
@@ -1,4 +1,8 @@
-import emojilib from '@lobehub/emojilib';
+/**
+ * `@lobehub/emojilib` exposes a bare `index.json` as its entry, which Node's ESM
+ * loader rejects without an explicit type attribute.
+ */
+import emojilib from '@lobehub/emojilib/index.json' with { type: 'json' };
 import emojiRegex from 'emoji-regex';
 
 export const getEmoji = (emoji: string): string | undefined => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
       "@lobehub/fluent-emoji/*": ["src/*"]
     }
   },
-  "include": ["src", "docs", "tests", "scripts", ".dumirc.ts", ".fatherrc.ts"]
+  "include": ["src", "docs", "tests", "scripts", ".dumirc.ts", "tsdown.config.ts"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -14,6 +14,11 @@ const external = [
   ...Object.keys(pkg.peerDependencies ?? {}),
 ];
 
+/**
+ * `unbundle` must stay on: `'use client'` lives in `src/FluentEmoji/index.tsx`,
+ * and a bundled build would drop it, turning the component into a server module
+ * under the Next.js App Router.
+ */
 export default defineConfig({
   dts: true,
   entry: ['src/index.ts'],

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'tsdown';
+
+const root = fileURLToPath(new URL('.', import.meta.url));
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+const external = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+];
+
+export default defineConfig({
+  dts: true,
+  entry: ['src/index.ts'],
+  external,
+  format: ['esm'],
+  outDir: 'es',
+  sourcemap: true,
+  unbundle: true,
+});


### PR DESCRIPTION
`@lobehub/fluent-emoji` cannot be imported through Node's ESM loader, which breaks every downstream consumer that resolves it outside a bundler (vitest with `environment: 'node'`, RSC, plain scripts):

```
ERR_UNSUPPORTED_DIR_IMPORT  es/index.js -> './FluentEmoji'
```

father's bundless output re-exports with extensionless relative specifiers, which only bundler resolution accepts. A second layer sits behind it: `@lobehub/emojilib`'s `main` is a bare `index.json`, which Node ESM rejects with `ERR_IMPORT_ATTRIBUTE_MISSING`.

## Changes

- father -> tsdown (same builder `@lobehub/ui` uses); emits `es/index.mjs` + `es/index.d.mts`
- `package.json`: `main`/`module`/`types` updated, explicit `exports` map added
- `@lobehub/emojilib` is bundled in (`noExternal`) so the entry no longer depends on a JSON `main`
- `tsconfig.json` include: `.fatherrc.ts` -> `tsdown.config.ts`

## Verification

Built output dropped into a consumer that has `@lobehub/ui@5.33.0` installed:

```
before: import('@lobehub/ui/base-ui') -> FAIL ERR_UNSUPPORTED_DIR_IMPORT
after:  import('@lobehub/ui/base-ui') -> OK, 185 exports
getEmoji('😀') = 😀
getEmojiNameByCharacter('😀') = grinning-face
```

`tsc --noEmit` passes. The repo has no test files (`vitest --passWithNoTests`).

## Note

`unbundle: false` here, unlike `@lobehub/ui`. With `unbundle: true`, bundling emojilib emits `es/node_modules/.pnpm/@lobehub_emojilib@1.0.0/.../index.mjs` — a pnpm store path baked into the published artifact. Bundled output is 3 files / 54 kB with `sideEffects: false` kept.